### PR TITLE
fix WinError handling

### DIFF
--- a/src/plugin_jm_server/driver.py
+++ b/src/plugin_jm_server/driver.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 
 def get_winDriver():
@@ -23,11 +24,11 @@ def get_winDriver():
             driver_list[i] = driver_name
             i += 1
         except PermissionError as e:
-            if '[WinError 21]' in str(e):
-                del driver_list[i]
-            # 异常类型不为 “设备未就绪” 的再次抛出异常供调试
-            else:
-                raise (PermissionError, e)
+            del driver_list[i]
+            mobj = re.match(r'\[WinError (\d+)\]', str(e))
+            # ERROR_NOT_READY, ERROR_ACCESS_DENIED
+            if mobj is not None and mobj.group(1) not in {'21', '5'}:
+                print(f'Drive {driver_name} unexpectedly unavailable: {e}')
         finally:
             num -= 1
 


### PR DESCRIPTION
https://github.com/hect0x7/plugin-jm-server/blob/880276ca6ff52f22e8a901c3cb1601cf918ea0db/src/plugin_jm_server/driver.py#L21-L30

`raise (PermissionError, e)` 会导致 `TypeError: exceptions must derive from BaseException`. 因为在python中不能raise任意类型。
有时磁盘必须要管理员权限才能访问，此pr会解决碰到`ERROR_ACCESS_DENIED`情况下http500的问题，同时在其他情况下打印日志辅以调试